### PR TITLE
Small correction to Promise.props example

### DIFF
--- a/docs/docs/api/promise.props.md
+++ b/docs/docs/api/promise.props.md
@@ -54,7 +54,7 @@ function directorySizeInfo(root) {
                 return stat;
             });
         }).then(_.flatten);
-    })(root).then(_);
+    })(root).then(_.chain);
 
     var smallest = stats.call("min", "size").call("pick", "size", "filePath").call("value");
     var largest = stats.call("max", "size").call("pick", "size", "filePath").call("value");


### PR DESCRIPTION
The second example for Promise.props has a bug in how it uses lodash. It needs `_.chain()` to work, not just `_()`.

PR for #1189
